### PR TITLE
Fixed Migration Errors and String length Issue

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -23,6 +24,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Schema::defaultStringLength(191);
     }
 }

--- a/database/migrations/2019_10_09_130903_create_profiles_table.php
+++ b/database/migrations/2019_10_09_130903_create_profiles_table.php
@@ -31,7 +31,8 @@ class CreateProfilesTable extends Migration
             $table->string('zipcode')->nullable();
             $table->integer('state_id')->nullable();
             $table->string('timezone')->nullable();
-            $table->json('contacts')->nullable();
+            $table->text('contacts')->nullable();
+            // $table->json('contacts')->nullable();
             $table->integer('currency_id');
             $table->timestamps();
 

--- a/database/migrations/2019_10_09_171721_create_subscription_plans_table.php
+++ b/database/migrations/2019_10_09_171721_create_subscription_plans_table.php
@@ -17,7 +17,8 @@ class CreateSubscriptionPlansTable extends Migration
             $table->bigIncrements('id');
             $table->string('name',255);
             $table->text('description')->nullable();
-            $table->json('features')->nullable();
+            // $table->json('features')->nullable();
+            $table->text('features')->nullable();
             $table->float('price');
             $table->timestamps();
         });

--- a/database/migrations/2019_10_09_214544_create_clients_table.php
+++ b/database/migrations/2019_10_09_214544_create_clients_table.php
@@ -26,7 +26,8 @@ class CreateClientsTable extends Migration
             $table->integer('state_id')->nullable();
             $table->string('zipcode')->nullable();
             $table->string('timezone')->nullable();
-            $table->json('contacts')->nullable();
+            $table->text('contacts')->nullable();
+            // $table->json('contacts')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2019_10_09_214740_create_estimates_table.php
+++ b/database/migrations/2019_10_09_214740_create_estimates_table.php
@@ -19,7 +19,8 @@ class CreateEstimatesTable extends Migration
             $table->integer('time');
             $table->integer('price_per_hour');
             $table->integer('equipment_cost');
-            $table->json('sub_contractors')->nullable();
+            $table->text('sub_contractors')->nullable();
+            // $table->json('sub_contractors')->nullable();
             $table->integer('similar_projects');
             $table->integer('rating');
             $table->integer('currency_id');

--- a/database/migrations/2019_10_09_215225_create_tasks_table.php
+++ b/database/migrations/2019_10_09_215225_create_tasks_table.php
@@ -18,7 +18,8 @@ class CreateTasksTable extends Migration
             $table->string('name');
             $table->mediumText('description')->nullable();
             $table->integer('progress');
-            $table->json('team')->nullable();
+            // $table->json('team')->nullable();
+            $table->text('team')->nullable();
             $table->date('start_date')->nullable();
             $table->date('due_date')->nullable();
             $table->integer('project_id');


### PR DESCRIPTION
MariaDB default engine doesnt support json data types at the moment... Hence better to use text to store json data and decode with `json_decode($data)` in the backend